### PR TITLE
Add e2e tests for adding users to group and verifying inclusion in response

### DIFF
--- a/tests/e2e/group_membership_test.go
+++ b/tests/e2e/group_membership_test.go
@@ -93,3 +93,40 @@ func TestGroupsRoute_MembershipOperations(t *testing.T) {
 	}
 
 }
+
+func TestGroupsRoute_AddUsersToGroupAndVerify(t *testing.T) {
+	// Create two users
+	user1 := tests.TestUtil_CreateUser(t, "testuser301", "testpassword301")
+	user2 := tests.TestUtil_CreateUser(t, "testuser401", "testpassword401")
+
+	// Create a group
+	group := tests.TestUtil_CreateGroup(t, user1.Token, "Test Group 3")
+
+	// Add user2 to the group
+	joinRequestBody := []byte(`{
+		"latitude": 12.971645,
+		"longitude": 77.594562
+	}`)
+	req := httptest.NewRequest("PUT", "/v1/groups/"+group.ID+"/join", bytes.NewBuffer(joinRequestBody))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+user2.Token)
+
+	resp := lo.Must(tests.App.Test(req, -1))
+	assert.Equal(t, fiber.StatusAccepted, resp.StatusCode)
+
+	// Verify that user2 is included in the group members
+	req = httptest.NewRequest("GET", "/v1/groups/"+group.ID+"?includeUsers=true", nil)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+user1.Token)
+
+	resp = lo.Must(tests.App.Test(req, -1))
+	assert.Equal(t, fiber.StatusOK, resp.StatusCode)
+
+	var groupResp dto.GroupResponse
+	body := lo.Must(io.ReadAll(resp.Body))
+	err := json.Unmarshal(body, &groupResp)
+	assert.NoError(t, err)
+
+	assert.Len(t, groupResp.Members, 1)
+	assert.Equal(t, user2.Id, groupResp.Members[0].UserID)
+}

--- a/tests/e2e/group_membership_test.go
+++ b/tests/e2e/group_membership_test.go
@@ -128,5 +128,5 @@ func TestGroupsRoute_AddUsersToGroupAndVerify(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Len(t, groupResp.Members, 1)
-	assert.Equal(t, user2.Id, groupResp.Members[0].UserID)
+	assert.Equal(t, user2.ID, groupResp.Members[0].UserID)
 }


### PR DESCRIPTION
Add e2e test to verify adding users to a group and their inclusion in the group members response.

* Add `TestGroupsRoute_AddUsersToGroupAndVerify` function in `tests/e2e/group_membership_test.go`
* Create two users for the test using `TestUtil_CreateUser`
* Create a group for the test using `TestUtil_CreateGroup`
* Add one user to the group and verify the inclusion of the user in the `GET /groups/:groupIdOrCode?includeUsers=true` response

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/championswimmer/api.midpoint.place/pull/5?shareId=e2ba4c23-9977-4d4e-9e33-ade402b7f899).