### PR TITLE
[Enhancement] - Calculate midpoint using only members near to Creator's Location

### DIFF
--- a/src/controllers/groups.go
+++ b/src/controllers/groups.go
@@ -99,6 +99,8 @@ func (c *GroupsController) GetGroupByIDorCode(groupIDorCode string, includeUsers
 		Creator: dto.GroupCreator{
 			ID:          group.Creator.ID,
 			DisplayName: group.Creator.DisplayName,
+			Latitude: group.Creator.Latitude,
+			Longitude: group.Creator.Longitude,
 		},
 		MidpointLatitude:  group.MidpointLatitude,
 		MidpointLongitude: group.MidpointLongitude,

--- a/src/dto/groups.go
+++ b/src/dto/groups.go
@@ -21,8 +21,10 @@ type UpdateGroupMidpointRequest struct {
 }
 
 type GroupCreator struct {
-	ID          uint   `json:"id"`
-	DisplayName string `json:"display_name"`
+	ID          	uint   		`json:"id"`
+	DisplayName 	string 		`json:"display_name"`
+	Latitude    	float64 	`json:"latitude"`
+	Longitude   	float64     `json:"longitude"`
 }
 
 type GroupResponse struct {

--- a/src/routes/groups.go
+++ b/src/routes/groups.go
@@ -257,7 +257,7 @@ func getGroup(ctx *fiber.Ctx) error {
 // 2. delete existing group places
 // 3. populate group places (parallelly) for all place types
 func _triggerGroupMidpointUpdate(group *dto.GroupResponse) {
-	groupResp, err := _recalculateGroupMidpoint(group.ID)
+	groupResp, err := _recalculateGroupMidpoint(group.ID, group.Creator.Latitude, group.Creator.Longitude)
 	if err != nil {
 		applogger.Error("Error recalculating group location", err)
 	}
@@ -282,9 +282,9 @@ func _triggerGroupMidpointUpdate(group *dto.GroupResponse) {
 	}
 }
 
-func _recalculateGroupMidpoint(groupID string) (*dto.GroupResponse, error) {
+func _recalculateGroupMidpoint(groupID string, creatorLatitude float64, creatorLongitude float64) (*dto.GroupResponse, error) {
 	applogger.Info("Recalculating group midpoint for group", groupID)
-	centroidLatitude, centroidLongitude, err := groupUsersController.CalculateGroupCentroid(groupID)
+	centroidLatitude, centroidLongitude, err := groupUsersController.CalculateGroupCentroid(groupID, dto.Location{Latitude: creatorLatitude, Longitude: creatorLongitude})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
fix: #10 

### Proposed fix:

1. Updated `CalculateGroupCentroid()` in `src/controllers/group_users.go` to calculate the average latitude and longitude of group members who share the same integer part of latitude and longitude as the creator.
2. Added a `creatorLocation` parameter to `CalculateGroupCentroid()` to pass the creator's coordinates.
3. Extended the `GroupCreator` struct in `src/dto/groups.go` to include `Latitude` and `Longitude`.
4. Passed the creator's coordinates to` _recalculateGroupMidpoint()` for use in `CalculateCentroid()`.

### Screenshot:

https://github.com/user-attachments/assets/cbf1f69d-b3a9-402c-b7a5-704b13180f00

