### PR TITLE
enahcement: add distance validation for JoinGroup controller using haversine formula

### DIFF
--- a/src/controllers/group_users.go
+++ b/src/controllers/group_users.go
@@ -4,6 +4,7 @@ import (
 	"github.com/championswimmer/api.midpoint.place/src/db"
 	"github.com/championswimmer/api.midpoint.place/src/db/models"
 	"github.com/championswimmer/api.midpoint.place/src/dto"
+	haversine "github.com/championswimmer/api.midpoint.place/src/utils"
 	"github.com/championswimmer/api.midpoint.place/src/utils/applogger"
 	"github.com/gofiber/fiber/v2"
 	"github.com/samber/lo"
@@ -33,7 +34,7 @@ func (c *GroupUsersController) JoinGroup(groupID string, userID uint, req *dto.G
 
 	// Check if group exists
 	var group models.Group
-	if err := c.db.First(&group, "id = ?", groupID).Error; err != nil {
+	if err := c.db.Preload("Creator").First(&group, "id = ?", groupID).Error; err != nil {
 		return nil, fiber.NewError(fiber.StatusNotFound, "Group not found")
 	}
 
@@ -60,6 +61,14 @@ func (c *GroupUsersController) JoinGroup(groupID string, userID uint, req *dto.G
 			}
 			applogger.Warn("User", userID, "is already in group", groupID, "- updating location")
 		}
+
+		applogger.Info("Calculating distance from creator's location")
+		var haversineDistance = haversine.Haversine(group.Creator.Latitude, group.Creator.Longitude, req.Latitude, req.Longitude)
+
+		if haversineDistance > float64(group.Radius) {
+			return fiber.NewError(fiber.StatusBadRequest, "You are too far from the creator's location. Please choose a closer location.")
+		}
+
 		applogger.Info("Joining group", groupID, "for user", userID, "transaction completed")
 		return nil
 	})

--- a/src/utils/haversine.go
+++ b/src/utils/haversine.go
@@ -1,0 +1,22 @@
+package haversine
+
+import "math"
+
+func Haversine(lat1, lon1, lat2, lon2 float64) float64 {
+	const R = 6371 // Earth radius in km
+
+	toRad := func(deg float64) float64 {
+		return deg * math.Pi / 180
+	}
+
+	dLat := toRad(lat2 - lat1)
+	dLon := toRad(lon2 - lon1)
+
+	a := math.Sin(dLat/2)*math.Sin(dLat/2) +
+		math.Cos(toRad(lat1))*math.Cos(toRad(lat2))*
+			math.Sin(dLon/2)*math.Sin(dLon/2)
+
+	c := 2 * math.Asin(math.Sqrt(a))
+
+	return R * c * 1000 // haversine distance in meteres
+}


### PR DESCRIPTION
> [!NOTE]
The code changes in this PR are made with help of AI.

<details>
<summary>View Prompts:</summary>

1. Explain the concept of Haversine distance and its formula. Also, give the code in JavaScript and explain it and give the code in Go as well.

2. In the group model I have `creatorId` which is of type `User`, and `User` model has `latitude` and `longitude` fields which I need to use in my controller logic. Can you help me with the way to populate user data (creator) by ID in this query?

    ```go
    var group models.Group
    if err := c.db.First(&group, "id = ?", groupID).Error; err != nil {
        return nil, fiber.NewError(fiber.StatusNotFound, "Group not found")
    }
    ```

3. What should be the code here so I can return that user is very far from creator's location, and suggest choosing a closer one?

    ```go
    applogger.Info("Calculating distance from creator's location")
    var haversineDistance = haversine.Haversine(group.Creator.Latitude, group.Creator.Longitude, req.Latitude, req.Longitude)
    if haversineDistance > float64(group.Radius) {
       // what should be the code here so I can return that user is very far from creator's, choose a closer location.
    }
    ```
    For reference, this is the code used to throw error in the same controller but I don't understand it:

    ```go
    // If the user is already in the group and the location has changed, update the location
    if groupUser.Latitude != req.Latitude || groupUser.Longitude != req.Longitude {
        groupUser.Latitude = req.Latitude
        groupUser.Longitude = req.Longitude
        if err := tx.Save(&groupUser).Error; err != nil {
            return fiber.NewError(fiber.StatusInternalServerError, "Failed to update user location in group")
        }
        applogger.Warn("User", userID, "is already in group", groupID, "- updating location")
    }
    ```

</details>

### Description:
Currently a user can join a group even if he is very far from the creator's location (for ex. event is in Delhi, and user joins from some location in Mumbai) - This skews the calculation of midpoint.

### Solution Implemented:
By calculating distance between user and creator using Haversine formula, we check if haversine distance is greater the the group radius.


### Additional Problems:
Right now I used group radius, but group radius is meant to find places within the radius where `midpoint` center of the circle.
What we can do is, we can give creator an option to set a limit for how far people from can join the group.

### Screenshots:
1. Not able to join, as very far from creator's location:
<img width="1438" alt="image" src="https://github.com/user-attachments/assets/9208e3a1-3e23-4239-9ff2-fdb1892d4228" />
2. Able to join, as distance between user and creator is less than the group radius:
<img width="1438" alt="image" src="https://github.com/user-attachments/assets/c0c22f19-f019-4a45-8bf8-702de1231e17" />
